### PR TITLE
[고급 레이아웃 컴포넌트] 도담(김민재) 미션 제출합니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@
 - 자식요소들은 style속성에 정렬하는 방향에 따라 height 혹은 width를 명시해줘야 합니다.
 
 ```tsx
-<MasonryLayout direction="column" gap={8} line={3}>
+<MasonryLayout direction="column" gap={8} lane={3}>
   <div style={{ height: `100px` }}>Item 1</div>
   <div style={{ height: `180px` }}>Item 2</div>
   <div style={{ height: `120px` }}>Item 3</div>

--- a/README.md
+++ b/README.md
@@ -41,3 +41,19 @@
   <div>Item 3</div>
 </Flex>
 ```
+
+## 4. Masonry Layout
+
+- 여러 크기의 아이템을 격자(벽돌) 형태로 정렬합니다.
+- 행 혹은 열의 수를 설정할 수 있습니다.
+- gap 속성을 통해 자식들간의 간격을 조절할 수 있습니다.
+- 자식요소들은 style속성에 정렬하는 방향에 따라 height 혹은 width를 명시해줘야 합니다.
+
+```tsx
+<MasonryLayout direction="column" gap={8} line={3}>
+  <div style={{ height: `100px` }}>Item 1</div>
+  <div style={{ height: `180px` }}>Item 2</div>
+  <div style={{ height: `120px` }}>Item 3</div>
+  <!-- 추가 아이템 -->
+</MasonryLayout>
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@d0dam/react-ui",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@d0dam/react-ui",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@babel/runtime": "^7.22.15",
         "@babel/runtime-corejs3": "^7.22.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d0dam/react-ui",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d0dam/react-ui",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d0dam/react-ui",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lib/components/Grid.tsx
+++ b/src/lib/components/Grid.tsx
@@ -1,12 +1,5 @@
 import React from "react";
-import type { GapFormat } from "../types";
-
-type Gap =
-  | {
-      row: GapFormat;
-      column: GapFormat;
-    }
-  | GapFormat;
+import type { Gap, GapFormat } from "../types";
 
 interface Props {
   rows: number;

--- a/src/lib/components/MasonryLayout.tsx
+++ b/src/lib/components/MasonryLayout.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { createArrayOfArrays, findIndexOfSmallest } from "../utils";
+import type { Gap, GapFormat } from "../types";
+
+interface Props {
+  direction?: "column" | "row";
+  gap: Gap;
+  line: number;
+  children: React.ReactElement[];
+}
+
+interface MasonryChild {
+  height: number;
+  child: React.ReactElement;
+}
+
+function MasonryLayout({ direction = "column", gap, line, children }: Props) {
+  const layoutArrayList = createArrayOfArrays<MasonryChild>(line);
+  let rowGap: GapFormat = 0;
+  let columnGap: GapFormat = 0;
+
+  if (typeof gap !== "object") {
+    rowGap = gap;
+    columnGap = gap;
+  } else {
+    ({ row: rowGap, column: columnGap } = gap);
+  }
+
+  const gridStyle = {
+    display: "grid",
+    gridTemplateColumns: `repeat(${line}, 1fr)`,
+    gap: columnGap || "0",
+  };
+
+  const lineStyle = {
+    display: "flex",
+    flexDirection: direction,
+    gap: rowGap || "0",
+  };
+
+  children.forEach((child) => {
+    const heightSumArray = layoutArrayList.map((array: MasonryChild[]) =>
+      array.reduce((sum, item) => sum + item.height, 0)
+    );
+    const targetIndex = findIndexOfSmallest(heightSumArray);
+    const value = { height: parseInt(child.props.style.height, 10), child };
+    layoutArrayList[targetIndex].push(value);
+  });
+
+  return (
+    <div style={gridStyle}>
+      {Array.from({ length: line }, (_, index) => (
+        <div key={index} style={lineStyle}>
+          {layoutArrayList[index].map((item) => item.child)}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default MasonryLayout;

--- a/src/lib/components/MasonryLayout.tsx
+++ b/src/lib/components/MasonryLayout.tsx
@@ -6,7 +6,7 @@ import type { Gap } from "../types";
 interface Props {
   direction?: "column" | "row";
   gap: Gap;
-  line: number;
+  lane: number;
   children: React.ReactElement[];
 }
 
@@ -15,13 +15,13 @@ interface MasonryChild {
   child: React.ReactElement;
 }
 
-function MasonryLayout({ direction = "column", gap, line, children }: Props) {
+function MasonryLayout({ direction = "column", gap, lane, children }: Props) {
   const dimensionProperty = direction === "column" ? "height" : "width";
-  const layoutArrayList = createArrayOfArrays<MasonryChild>(line);
+  const layoutArrayList = createArrayOfArrays<MasonryChild>(lane);
   const { rowGap, columnGap } = parseGap(gap);
 
-  const rowGrid = { gridTemplateRows: `repeat(${line}, 1fr)`, height: "100%" };
-  const columnGrid = { gridTemplateColumns: `repeat(${line}, 1fr)` };
+  const rowGrid = { gridTemplateRows: `repeat(${lane}, 1fr)`, height: "100%" };
+  const columnGrid = { gridTemplateColumns: `repeat(${lane}, 1fr)` };
 
   const gridStyle = {
     display: "grid",
@@ -30,7 +30,7 @@ function MasonryLayout({ direction = "column", gap, line, children }: Props) {
     ...(direction === "column" && columnGrid),
   };
 
-  const lineStyle = {
+  const laneStyle = {
     display: "flex",
     flexDirection: direction,
     gap: direction === "column" ? rowGap : columnGap,
@@ -47,8 +47,8 @@ function MasonryLayout({ direction = "column", gap, line, children }: Props) {
 
   return (
     <div style={gridStyle}>
-      {Array.from({ length: line }, (_, index) => (
-        <div key={index} style={lineStyle}>
+      {Array.from({ length: lane }, (_, index) => (
+        <div key={index} style={laneStyle}>
           {layoutArrayList[index].map((item) => item.child)}
         </div>
       ))}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,6 @@
 import Container from "./components/Container";
 import Grid from "./components/Grid";
 import Flex from "./components/Flex";
+import MasonryLayout from "./components/MasonryLayout";
 
-export { Container, Grid, Flex };
+export { Container, Grid, Flex, MasonryLayout };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,1 +1,8 @@
 export type GapFormat = number | `${number}px` | `${number}em` | `${number}rem`;
+
+export type Gap =
+  | {
+      row: GapFormat;
+      column: GapFormat;
+    }
+  | GapFormat;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,31 @@
+export function getRandomNumberInRange(first: number, second: number) {
+  if (first > second) [first, second] = [second, first];
+
+  return Math.floor(Math.random() * (second - first + 1)) + first;
+}
+
+export function findIndexOfSmallest(arr: number[]) {
+  if (arr.length === 0) return -1;
+
+  let smallestIndex = 0;
+  let smallestValue = arr[0];
+
+  for (let i = 1; i < arr.length; i++) {
+    if (arr[i] < smallestValue) {
+      smallestValue = arr[i];
+      smallestIndex = i;
+    }
+  }
+
+  return smallestIndex;
+}
+
+export function createArrayOfArrays<T>(length: number) {
+  const arrayOfArrays: T[][] = [];
+
+  for (let i = 0; i < length; i++) {
+    arrayOfArrays.push([]);
+  }
+
+  return arrayOfArrays;
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,28 +4,16 @@ export function getRandomNumberInRange(first: number, second: number) {
   return Math.floor(Math.random() * (second - first + 1)) + first;
 }
 
-export function findIndexOfSmallest(arr: number[]) {
-  if (arr.length === 0) return -1;
+export function findIndexOfSmallest(array: number[]) {
+  if (array.length === 0) return -1;
 
-  let smallestIndex = 0;
-  let smallestValue = arr[0];
-
-  for (let i = 1; i < arr.length; i++) {
-    if (arr[i] < smallestValue) {
-      smallestValue = arr[i];
-      smallestIndex = i;
-    }
-  }
-
-  return smallestIndex;
+  return array.reduce(
+    (smallestIndex, currentValue, currentIndex, array) =>
+      currentValue < array[smallestIndex] ? currentIndex : smallestIndex,
+    0
+  );
 }
 
-export function createArrayOfArrays<T>(length: number) {
-  const arrayOfArrays: T[][] = [];
-
-  for (let i = 0; i < length; i++) {
-    arrayOfArrays.push([]);
-  }
-
-  return arrayOfArrays;
+export function createArrayOfArrays<T>(length: number): T[][] {
+  return Array.from({ length }, () => [] as T[]);
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,5 @@
+import type { Gap, GapFormat } from "./types";
+
 export function getRandomNumberInRange(first: number, second: number) {
   if (first > second) [first, second] = [second, first];
 
@@ -16,4 +18,13 @@ export function findIndexOfSmallest(array: number[]) {
 
 export function createArrayOfArrays<T>(length: number): T[][] {
   return Array.from({ length }, () => [] as T[]);
+}
+
+export function parseGap(gap: Gap) {
+  if (typeof gap !== "object") {
+    return { rowGap: gap, columnGap: gap };
+  }
+
+  const { row = 0, column = 0 } = gap;
+  return { rowGap: row, columnGap: column };
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import type { Gap, GapFormat } from "./types";
+import type { Gap } from "./types";
 
 export function getRandomNumberInRange(first: number, second: number) {
   if (first > second) [first, second] = [second, first];

--- a/src/stories/MasonryLayout.stories.tsx
+++ b/src/stories/MasonryLayout.stories.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { MasonryLayout } from "../lib";
+import type { Meta, StoryObj } from "@storybook/react";
+import { getRandomNumberInRange } from "../lib/utils";
+
+const meta: Meta<typeof MasonryLayout> = {
+  title: "MasonryLayout",
+  component: MasonryLayout,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof MasonryLayout>;
+
+const childrenDefault: React.ReactElement[] = Array.from(
+  { length: 100 },
+  (_, index) => (
+    <div
+      key={index}
+      style={{
+        background: `#${getRandomNumberInRange(100000, 999999)}`,
+        height: `${getRandomNumberInRange(100, 400)}px`,
+      }}
+    />
+  )
+);
+
+export const Default: Story = {
+  args: {
+    children: childrenDefault,
+    direction: "column",
+    gap: 4,
+    line: 4,
+  },
+};
+
+export const ConfigGap: Story = {
+  args: {
+    children: childrenDefault,
+    direction: "column",
+    gap: { row: 8, column: 20 },
+    line: 3,
+  },
+};

--- a/src/stories/MasonryLayout.stories.tsx
+++ b/src/stories/MasonryLayout.stories.tsx
@@ -25,6 +25,20 @@ const childrenDefault: React.ReactElement[] = Array.from(
   )
 );
 
+const childrenRow: React.ReactElement[] = Array.from(
+  { length: 100 },
+  (_, index) => (
+    <div
+      key={index}
+      style={{
+        background: `#${getRandomNumberInRange(100000, 999999)}`,
+        width: `${getRandomNumberInRange(100, 400)}px`,
+        height: "30vh",
+      }}
+    />
+  )
+);
+
 export const Default: Story = {
   args: {
     children: childrenDefault,
@@ -39,6 +53,15 @@ export const ConfigGap: Story = {
     children: childrenDefault,
     direction: "column",
     gap: { row: 8, column: 20 },
+    line: 3,
+  },
+};
+
+export const ConfigRow: Story = {
+  args: {
+    children: childrenRow,
+    direction: "row",
+    gap: 8,
     line: 3,
   },
 };

--- a/src/stories/MasonryLayout.stories.tsx
+++ b/src/stories/MasonryLayout.stories.tsx
@@ -44,7 +44,7 @@ export const Default: Story = {
     children: childrenDefault,
     direction: "column",
     gap: 4,
-    line: 4,
+    lane: 4,
   },
 };
 
@@ -53,7 +53,7 @@ export const ConfigGap: Story = {
     children: childrenDefault,
     direction: "column",
     gap: { row: 8, column: 20 },
-    line: 3,
+    lane: 3,
   },
 };
 
@@ -62,6 +62,6 @@ export const ConfigRow: Story = {
     children: childrenRow,
     direction: "row",
     gap: 8,
-    line: 3,
+    lane: 3,
   },
 };


### PR DESCRIPTION
# 🎯 2단계. 고급 레이아웃 컴포넌트

## 공통
- [x] 의미있는 커밋 메시지 작성
- [x] PR에 관련 없는 변경 사항이 포함 유무 확인

## 컴포넌트 요구사항
- [x] 선택한 컴포넌트의 기능 구현
- [x] npm 배포
- [x] README.md에 코드 저자로서 특히 고민한 부분과 의도 설명

## 📌 구현한 내용 설명

안녕하세요 솔로스타~! 이번에는 Masonry Layout Component를 구현해 보았어요!


우선 지금 컴포넌트는 자식 요소에 높이나 폭을 꼭 명시해 주어야 정렬되게끔 구현해 놓았습니다! 대부분 적어서 쓰는 예시가 많더라구요..

- css 위주의 방식도 있지만, 자식요소들은 좀 더 정렬 순서대로 채우게끔 하고 싶어서 css위주보다는 js 로직 위주의 정렬 방법을 사용하였습니다!

그래도 뭔가 높이나 폭을 전달해주지 않아도 알아서 높이나 폭에 맞추어 정렬이 되게끔 구현해 보려고 열심히 발악해 보았습니다.
그런데 이게 쉽지 않더군요.. 컴포넌트의 자식으로 전달받은 요소의 폭을 알려면 우선 element로써 접근해서 offsetHeight와 같은 경로로 알 수 있을텐데 이를 사용하면 sideEffect가 너무 커지고 ref에 자식요소를 하나하나 담아가면서 무한 반복문을 돌려야되는 구조가 되어버린다던가...
아니면 애초에 Masonry 전용 자식 컴포넌트를 ref를 같이 묶어 만들어서 사용자에게 사용하게끔 해야된다던가.. 무언가 마음에 들지 않는 구조였습니다.
그리고 곰곰히 생각해 보았는데, 과연 요소의 크기를 알아서 판단하고 정렬을 완전 프로그램에 맡기는 것도 문맥상 좀 어색한 것 같기도 하구요..
솔로스타는 혹시 자식 컴포넌트에 높이나 폭을 주지 않더라도 화면에 나타나는 폭을 유추해 폭이나 높이를 알아낼 수 있는 좋은 방법을 알고 있을까요? 알면 공유해주셨으면 좋겠어요!

이번 컴포넌트는 저번에 사용한 타입들을 활용했어요!
우선 가로모드와 세로모드를 지원하구요! 가로모드의 경우에는 자식 요소 안에 내용물이 없는경우 높이도 지정을 해 주어야지 잘 정렬된 모습을 볼 수 있습니다~!
폭도 달리해줄 수 있으니 참고 부탁드려요!

이외에 솔로스타는 이 컴포넌트에 대해 어떻게 접근해볼지 궁금하네요! 라이브러리의 제왕인 솔로스타의 의견.. 기대하고 있겠습니다~!

[reaadme 보러가기!](https://github.com/D0Dam/layout-component/tree/d0dam#readme)
[스토리북 보러가기!](https://6507e709132795a10f9193be-cmoggyqlmg.chromatic.com/)
[배포 페이지 보러가기!](https://www.npmjs.com/package/@d0dam/react-ui)

