### PR TITLE
[고급 레이아웃 컴포넌트] 애슐리(허서영) 미션 제출합니다.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -9,6 +9,7 @@
     "^@emotion/(.*)$",
     "^@storybook/(.*)$",
     "^@components/(.*)$",
+    "^@hooks/(.*)$",
     "^@type/(.*)$",
     "^@constants/(.*)$",
     "^@utils/(.*)$",

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -23,6 +23,7 @@ const config: StorybookConfig = {
         ...config.resolve.alias,
         '@': path.resolve(__dirname, '../src'),
         '@components': path.resolve(__dirname, '../src/components'),
+        '@hooks': path.resolve(__dirname, '../src/hooks'),
         '@type': path.resolve(__dirname, '../src/types'),
         '@styles': path.resolve(__dirname, '../src/styles'),
         '@constants': path.resolve(__dirname, '../src/constants'),

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -14,6 +14,9 @@ const preview: Preview = {
       },
     },
   },
+  argTypes: {
+    tag: { control: 'select', options: ['div', 'p', 'span', 'section', 'aside', 'article', 'ul'] },
+  },
 };
 
 export default preview;

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ import { Container } from '@ashleysyheo/layout-component';
 </Container>;
 ```
 
-## Flex
+## Flex 컴포넌트
 
 Flex 레이아웃을 만들기 위한 컴포넌트입니다.
 
@@ -49,6 +49,18 @@ import { Grid } from '@ashleysyheo/layout-component';
 </Grid>;
 ```
 
+## Masonry 컴포넌트
+
+Masonry 레이아웃을 만들기 위한 컴포넌트입니다.
+
+```tsx
+import { Masonry } from '@ashleysyheo/layout-component';
+
+<Masonry tag="ul" columns={5} spacing={16}>
+  {/* ReactNode 형태의 children을 전달 */}
+</Masonry>;
+```
+
 <br>
 
-더 자세한 사용 방법은 [스토리북](https://6502b9dcc6bfd98bc2197bb9-uxfezcgzsn.chromatic.com)에서 확인해 보세요.
+더 자세한 사용 방법은 [스토리북](https://6502b9dcc6bfd98bc2197bb9-qdtwbtmkbo.chromatic.com)에서 확인해 보세요.

--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ import { Masonry } from '@ashleysyheo/layout-component';
 
 <br>
 
-더 자세한 사용 방법은 [스토리북](https://6502b9dcc6bfd98bc2197bb9-qdtwbtmkbo.chromatic.com)에서 확인해 보세요.
+더 자세한 사용 방법은 [스토리북](https://6502b9dcc6bfd98bc2197bb9-nwqjfzyzri.chromatic.com)에서 확인해 보세요.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ashleysyheo/layout",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ashleysyheo/layout",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.11.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ashleysyheo/layout",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ashleysyheo/layout",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ashleysyheo/layout",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Responsive layout components for React",
   "homepage": "https://github.com/ashleysyheo/layout-component",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ashleysyheo/layout",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Responsive layout components for React",
   "homepage": "https://github.com/ashleysyheo/layout-component",
   "main": "dist/index.js",

--- a/src/components/Masonry.tsx
+++ b/src/components/Masonry.tsx
@@ -1,0 +1,59 @@
+import type { ComponentPropsWithoutRef, ElementType } from 'react';
+import { useRef } from 'react';
+
+import { css } from '@emotion/react';
+
+import { useMasonry } from '@hooks/useMasonry';
+
+import type { ResponsiveValue } from '@type/index';
+
+interface MasonryProps extends ComponentPropsWithoutRef<ElementType> {
+  /**
+   * Masonry 컴포넌트가 사용할 HTML 태그
+   *
+   * @default 'div'
+   */
+  tag?: ElementType;
+  /**
+   * Masonry 컴포넌트의 열의 개수
+   */
+  columns: number | ResponsiveValue;
+  /**
+   * Masonry 컴포넌트 내 아이템들 사이의 간격 (px 단위로 변환)
+   *
+   */
+  spacing: number;
+}
+
+function Masonry({ tag = 'div', columns, spacing, children, ...attributes }: MasonryProps) {
+  const Tag = tag;
+  const masonryRef = useRef<HTMLElement>(null);
+  const { maxColumnHeight, childrenMediaQueries } = useMasonry(masonryRef, columns, spacing);
+
+  return (
+    <Tag
+      ref={masonryRef}
+      css={css({
+        display: 'flex',
+        flexFlow: 'column wrap',
+        alignContent: 'flex-start',
+        rowGap: spacing,
+        width: '100%',
+        height: maxColumnHeight,
+        marginLeft: `-${spacing / 2}px`,
+
+        '& > *': {
+          boxSizing: 'border-box',
+          margin: `0 ${spacing / 2}px !important`,
+          ...childrenMediaQueries['default'],
+          ...childrenMediaQueries,
+        },
+      })}
+      {...attributes}
+    >
+      {children}
+    </Tag>
+  );
+}
+
+export default Masonry;

--- a/src/hooks/useMasonry.ts
+++ b/src/hooks/useMasonry.ts
@@ -1,0 +1,83 @@
+import type { CSSProperties, RefObject } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+
+import type { BreakPoints, ResponsiveValue } from '@type/index';
+
+import { generateMediaQueryStyles } from '@utils/mediaQuery';
+
+export const useMasonry = (
+  masonryRef: RefObject<HTMLElement>,
+  columns: number | ResponsiveValue,
+  spacing: number
+) => {
+  const [maxColumnHeight, setMaxColumnHeight] = useState<number>();
+
+  const childrenResponsiveProperties = {
+    width:
+      typeof columns === 'object'
+        ? Object.keys(columns).reduce((acc: { [key: string]: string }, key) => {
+            const breakpoint = key as BreakPoints;
+
+            if (typeof columns === 'number' || !columns[breakpoint]) return acc;
+
+            acc[breakpoint] = `calc((100% - ${(Number(columns[breakpoint]) - 1) * spacing}px) / ${
+              columns[breakpoint]
+            })`;
+
+            return acc;
+          }, {})
+        : `calc((100% - ${(columns - 1) * spacing}px) / ${columns}) !important`,
+  };
+
+  const childrenMediaQueries: { [key: string]: CSSProperties } = generateMediaQueryStyles(
+    childrenResponsiveProperties
+  );
+
+  const handleResize = useCallback(() => {
+    const masonry = masonryRef.current;
+
+    if (!masonry) return;
+
+    const parentWidth = masonry.clientWidth;
+    const firstChild = masonry.firstChild as HTMLElement;
+    const firstChildComputedStyle = window.getComputedStyle(firstChild);
+    const firstChildWidth = firstChild ? parseInt(firstChildComputedStyle.width) : 0;
+
+    if (parentWidth === 0 || firstChildWidth === 0) return;
+
+    const firstChildMarginLeft = parseInt(firstChildComputedStyle.marginLeft);
+    const firstChildMarginRight = parseInt(firstChildComputedStyle.marginRight);
+
+    const currentNumberOfColumns = Math.round(
+      parentWidth / (firstChildWidth + firstChildMarginLeft + firstChildMarginRight)
+    );
+    const columnHeights = new Array<number>(currentNumberOfColumns).fill(0);
+
+    Array.from(masonry.childNodes).forEach((child) => {
+      const childElement = child as HTMLElement;
+      const childComputedStyle = window.getComputedStyle(childElement);
+      const childHeight = parseInt(childComputedStyle.height);
+
+      const currentMinColumnIndex = columnHeights.indexOf(Math.min(...columnHeights));
+      columnHeights[currentMinColumnIndex] += childHeight + spacing;
+      setMaxColumnHeight(Math.max(...columnHeights));
+
+      const order = currentMinColumnIndex + 1;
+      childElement.style.order = String(order);
+    });
+  }, [masonryRef, spacing]);
+
+  useEffect(() => {
+    const resizeObserver = new ResizeObserver(handleResize);
+
+    if (masonryRef.current) {
+      resizeObserver.observe(masonryRef.current);
+    }
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [handleResize, masonryRef]);
+
+  return { maxColumnHeight, childrenMediaQueries };
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,5 +3,6 @@ import LayoutProvider from '@/LayoutProvider';
 import Container from '@components/Container';
 import Flex from '@components/Flex';
 import Grid from '@components/Grid';
+import Masonry from '@components/Masonry';
 
-export { LayoutProvider, Container, Flex, Grid };
+export { LayoutProvider, Container, Flex, Grid, Masonry };

--- a/src/stories/Flex.stories.tsx
+++ b/src/stories/Flex.stories.tsx
@@ -16,7 +16,6 @@ const meta = {
     },
   },
   argTypes: {
-    tag: { control: 'select', options: ['div', 'p', 'span', 'section', 'aside', 'article'] },
     rowGap: { control: { type: 'text' } },
     columnGap: { control: { type: 'text' } },
     gap: { control: { type: 'text' } },

--- a/src/stories/Flex.stories.tsx
+++ b/src/stories/Flex.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import Container from '@components/Container';
 import Flex from '@components/Flex';
 
-import { getRandomHexColor, getRandomNumber } from '@utils/random';
+import { getRandomHSLColor, getRandomNumber } from '@utils/random';
 
 const meta = {
   title: 'Flex',
@@ -64,7 +64,7 @@ export const Example2: Story = {
               key={index}
               width={randomSize}
               height={randomSize}
-              backgroundColor={getRandomHexColor()}
+              backgroundColor={getRandomHSLColor({ hue: 205 })}
             />
           );
         })}

--- a/src/stories/Grid.stories.tsx
+++ b/src/stories/Grid.stories.tsx
@@ -13,7 +13,6 @@ const meta = {
     },
   },
   argTypes: {
-    tag: { control: 'select', options: ['div', 'p', 'span', 'section', 'aside', 'article'] },
     css: {
       control: { type: 'object' },
       description: '스타일을 추가하거나 오버라이딩할 수 있는 방법',

--- a/src/stories/Masonry.mdx
+++ b/src/stories/Masonry.mdx
@@ -1,0 +1,25 @@
+import { Canvas, Controls, Description, Meta, Source } from '@storybook/blocks';
+
+import * as MasonryStories from './Masonry.stories.tsx';
+
+<Meta of={MasonryStories} />
+
+# Masonry
+
+<Description />
+
+<Canvas of={MasonryStories.Example1} sourceState="shown" />
+
+## Props
+
+<Controls exclude="children" />
+
+## Examples
+
+### Example 1
+
+<Canvas of={MasonryStories.Example1} />
+
+### Example 2
+
+<Canvas of={MasonryStories.Example2} />

--- a/src/stories/Masonry.stories.tsx
+++ b/src/stories/Masonry.stories.tsx
@@ -19,7 +19,7 @@ const meta = {
     tag: 'ul',
     children: (
       <>
-        {Array.from({ length: 20 }, (_, index) => (
+        {Array.from({ length: 10 }, (_, index) => (
           <li
             style={{
               height: getRandomNumber(100, 500),

--- a/src/stories/Masonry.stories.tsx
+++ b/src/stories/Masonry.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Masonry from '@components/Masonry';
+
+import { getRandomHSLColor, getRandomNumber } from '@utils/random';
+
+const meta = {
+  title: 'Masonry',
+  component: Masonry,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '여러 크기의 아이템을 격자 형태로 정렬하되, 각 열의 높이가 동일하지 않아 빈 공간이 최소화되는 Masonry 레이아웃을 만들기 위한 컴포넌트.',
+      },
+    },
+  },
+  args: {
+    tag: 'ul',
+    children: (
+      <>
+        {Array.from({ length: 20 }, (_, index) => (
+          <li
+            style={{
+              height: getRandomNumber(100, 500),
+              backgroundColor: getRandomHSLColor({
+                hue: 205,
+                minS: 100,
+                maxS: 100,
+                minL: 70,
+                maxL: 90,
+              }),
+              borderRadius: '8px',
+            }}
+            key={index}
+          />
+        ))}
+      </>
+    ),
+  },
+} satisfies Meta<typeof Masonry>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Example1: Story = {
+  args: {
+    columns: { xs: 1, sm: 2, md: 3, lg: 4 },
+    spacing: 24,
+  },
+};
+
+export const Example2: Story = {
+  args: {
+    columns: 5,
+    spacing: 24,
+  },
+};

--- a/src/stories/Masonry.stories.tsx
+++ b/src/stories/Masonry.stories.tsx
@@ -19,7 +19,7 @@ const meta = {
     tag: 'ul',
     children: (
       <>
-        {Array.from({ length: 10 }, (_, index) => (
+        {Array.from({ length: 20 }, (_, index) => (
           <li
             style={{
               height: getRandomNumber(100, 500),

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -11,4 +11,8 @@ export const GlobalStyle = css({
     fontFamily: `system-ui, -apple-system, BlinkMacSystemFont, 'Open Sans', 'Helvetica Neue'`,
     fontSize: '16px',
   },
+
+  'ul, ol, li': {
+    listStyle: 'none',
+  },
 });

--- a/src/utils/random.ts
+++ b/src/utils/random.ts
@@ -7,3 +7,24 @@ export const getRandomHexColor = () => {
 
   return `#${color}`;
 };
+
+interface GetRandomHSLColorParams {
+  hue: number;
+  minS?: number;
+  maxS?: number;
+  minL?: number;
+  maxL?: number;
+}
+
+export const getRandomHSLColor = ({
+  hue,
+  minS = 10,
+  maxS = 90,
+  minL = 10,
+  maxL = 90,
+}: GetRandomHSLColorParams) => {
+  const saturation = getRandomNumber(minS, maxS); // Generate a random saturation value between 0% and 100%
+  const lightness = getRandomNumber(minL, maxL); // Generate a random lightness value between 0% and 100%
+
+  return `hsl(${hue}, ${saturation}%, ${lightness}%)`;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "paths": {
       "@/*": ["./src/*"],
       "@components/*": ["./src/components/*"],
+      "@hooks/*": ["./src/hooks/*"],
       "@type/*": ["./src/types/*"],
       "@styles/*": ["./src/styles/*"],
       "@constants/*": ["./src/constants/*"],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,7 @@ module.exports = {
     alias: {
       '@': path.resolve(__dirname, './src'),
       '@components': path.resolve(__dirname, './src/components'),
+      '@hooks': path.resolve(__dirname, './src/hooks'),
       '@type': path.resolve(__dirname, './src/types'),
       '@styles': path.resolve(__dirname, './src/styles'),
       '@constants': path.resolve(__dirname, './src/constants'),


### PR DESCRIPTION
# 🎯 2단계. 고급 레이아웃 컴포넌트

### [npm 배포 링크](https://www.npmjs.com/package/@ashleysyheo/layout)
### [스토리북 배포 링크](https://6502b9dcc6bfd98bc2197bb9-nwqjfzyzri.chromatic.com/?path=/docs/container--docs)

## 공통
- [x] 의미있는 커밋 메시지 작성
- [x] PR에 관련 없는 변경 사항이 포함 유무 확인

## 컴포넌트 요구사항
- [x] 선택한 컴포넌트의 기능 구현
- [x] npm 배포
- [x] README.md에 코드 저자로서 특히 고민한 부분과 의도 설명
- [ ] 테스트 코드를 작성하였나요? (선택 사항)

## 📌 구현한 내용 설명
안녕하세요 노아 😊

이번 미션으로 Masonry 컴포넌트를 구현해 봤습니다!

- 열의 수를 설정할 수 있음 
- 각 열의 너비가 고정되어 있음
- 각 아이템들이 빈 공간 없이 정렬되어 있음
- 마지막 하단은 각 열의 높이 맞춰 자유롭게 정리됨

<br>

예전부터 핀터레스트 같은 레이아웃을 만들어보고 싶어서 선택했는데, 생각보다 많이 어렵더군요...... 

Masonry 레이아웃을 만들기 위한 여러가지 방법을 찾아보다가 flex를 이용해서 만드는 방법을 선택했습니다! 
원래는 grid를 통해서 쉽게 만들 수 있을 것이라고 생각했는데, 아직 grid가 익숙하지 않아서 flex를 선택했습니다.  

<img width="999" alt="Screenshot 2023-09-25 at 10 59 46 PM" src="https://github.com/woowacourse/layout-component/assets/51967731/d3521b0a-655f-44e1-95a4-3fcc1979088a">

<br>

이 컴포넌트를 사용하기 위해서는 `columns`와 `spacing`만 입력해 주면 됩니다. `columns`는 Grid 컴포넌트처럼 숫자 또는 객체를 입력 가능하게 해서 반응형을 지원하고 있습니다. 


https://github.com/woowacourse/layout-component/assets/51967731/f00897bb-58f6-4319-a542-9cec2cfe7c59

이번에는 `spacing`은 무조건 숫자만 입력 가능하게 했습니다. `spacing`을 이용해서 container의 높이를 계산하고 있어서 편리하게 계산하기 위해서 그렇게 했습니다. 그리고 일반적으로 `gap`, `spacing`에 `px` 이외의 단위를 자주 사용하지 않을 것이라고 생각해서 숫자만 입력 가능하게 했는데, 노아는 이 부분에 대해서 어떻게 생각하시나요?

#### ResizeObserver
현재 container의 높이를 알아야 사용자가 원하는 column 수에 맞춰서 보여줄 수 있습니다. 그래서 `columns` props에 반응형 값을 넘겨주면 화면 너비가 변함에 따라 높이를 재계산해야 해서 이를 위해 `ResizeObserver`를 사용했습니다. 

#### order
> 마지막 하단은 각 열의 높이 맞춰 자유롭게 정리됨

마지막 하단 부분의 높낮이를 최소화하기 위해서 `order` 프로퍼티를 사용해 봤습니다! Flex 요소의 정렬 순서를 지정할 수 있는 속성인데 한 번 사용해 봤습니다. 

[mdn - order](https://developer.mozilla.org/en-US/docs/Web/CSS/order)


