### PR TITLE
[고급 레이아웃 컴포넌트] 파인(임낭경) 미션 제출합니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This modal is simple react-layout-component.
 
 - Typescript support
 
+For more Information: [See Component Docs](https://nangkyeonglim.github.io/react-layout-component-docs/docs/navigation/tab)
+
 ## Components
 
 Includes the following components:
@@ -121,6 +123,62 @@ const Example = () => {
       <div>hi</div>
       <div>hi</div>
     </Flex>
+  );
+};
+
+export default Example;
+```
+
+## Tab
+
+Tabs organize and allow navigation between groups of content that are related and at the same level of hierarchy.
+
+The components are as follows:
+
+- TabProvider
+
+[optional]
+
+- `defaultIndex: number` (default: 0)
+- `index: number`: for Controlled Tabs
+- `onChange: any`: for Controlled Tabs
+
+- Tabs
+- Tab
+
+  [optional]
+
+  - `icon: ReactElement`
+  - `iconDirection: 'row' | 'column'` (default: column)
+
+- TabPanels
+- TabPanel
+
+#### Usage
+
+```javascript
+import {
+  TabProvider,
+  Tabs,
+  Tab,
+  TabPanels,
+  TabPanel,
+} from '@fine1012/react-modal';
+
+const Example = () => {
+  return (
+    <TabProvider>
+      <Tabs>
+        <Tab label='tab1' />
+        <Tab label='tab2' />
+        <Tab label='tab3' />
+      </Tabs>
+      <TabPanels>
+        <TabPanel>tab 1 section</TabPanel>
+        <TabPanel>tab 2 section</TabPanel>
+        <TabPanel>tab 3 section</TabPanel>
+      </TabPanels>
+    </TabProvider>
   );
 };
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Includes the following components:
 - Container
 - Flex
 - Grid
+- Tab
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,14 @@
 {
   "name": "@fine1012/react-layout-component",
-  "version": "0.1.4",
+  "version": "0.1.9",
   "private": false,
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "browser": "./browser/specific/main.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "description": "React Layout Component",
   "repository": {
     "type": "git",
@@ -27,15 +31,17 @@
     "prepare": "rm -rf dist && mkdir dist && tsc"
   },
   "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-scripts": "5.0.1",
     "@emotion/react": "^11.11.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",
     "typescript": "^4.9.5"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1"
   },
   "eslintConfig": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fine1012/react-layout-component",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "main": "dist/index.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fine1012/react-layout-component",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "private": false,
   "main": "dist/index.js",
   "exports": {

--- a/src/components/Tab/Tab.tsx
+++ b/src/components/Tab/Tab.tsx
@@ -69,7 +69,7 @@ const buttonStyle = ({ isSelected, iconDirection, hidden }: StyleProps) => {
     },
 
     '&:not(:disabled):hover': {
-      backgroundColor: '#bfbfbf',
+      backgroundColor: isSelected ? '#fff' : '#bfbfbf',
     },
   });
 };

--- a/src/components/Tab/Tab.tsx
+++ b/src/components/Tab/Tab.tsx
@@ -1,0 +1,75 @@
+/** @jsxImportSource @emotion/react */
+
+import { ComponentPropsWithoutRef, ReactElement } from 'react';
+import { useTabContext } from './useTab';
+import { css } from '@emotion/react';
+
+type IconDirection = 'row' | 'column';
+
+interface Props extends ComponentPropsWithoutRef<'button'> {
+  label: string;
+  icon?: ReactElement;
+  iconDirection?: IconDirection;
+  tabId?: number;
+}
+
+const Tab = ({
+  label,
+  icon,
+  iconDirection = 'column',
+  tabId = 0,
+  disabled,
+  hidden = false,
+}: Props) => {
+  const { tabIndex, onTabIndexChange } = useTabContext();
+  const isSelected = tabId === tabIndex;
+
+  return (
+    <button
+      css={buttonStyle({ isSelected, hidden, iconDirection })}
+      id={`tab-${tabId}`}
+      disabled={disabled}
+      role='tab'
+      aria-selected={isSelected}
+      aria-controls={`panel-${tabId}`}
+      onClick={() => onTabIndexChange(tabId)}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+};
+
+export default Tab;
+
+type StyleProps = {
+  isSelected: boolean;
+  iconDirection: IconDirection;
+  hidden: boolean;
+};
+
+const buttonStyle = ({ isSelected, iconDirection, hidden }: StyleProps) => {
+  return css({
+    display: hidden ? 'none' : 'flex',
+    flexDirection: `${iconDirection}`,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: '4px',
+    width: '100%',
+    padding: '12px 16px',
+    fontSize: '14px',
+    backgroundColor: isSelected ? '#fff' : 'transparent',
+    border: '1px solid transparent',
+    borderRadius: '8px',
+    cursor: 'pointer',
+    transition: 'all 0.2s ease-in',
+
+    '& > svg': {
+      width: '16px',
+    },
+
+    '&:not(:disabled):hover': {
+      backgroundColor: '#bfbfbf',
+    },
+  });
+};

--- a/src/components/Tab/TabPanel.tsx
+++ b/src/components/Tab/TabPanel.tsx
@@ -1,0 +1,22 @@
+import { PropsWithChildren } from 'react';
+import { useTabContext } from './useTab';
+
+type Props = {
+  tabId?: number;
+};
+
+const TabPanel = ({ tabId = 0, children }: PropsWithChildren<Props>) => {
+  const { tabIndex } = useTabContext();
+
+  return (
+    <>
+      {tabId === tabIndex && (
+        <div role='tabpanel' aria-labelledby={`panel-${tabId}`}>
+          {children}
+        </div>
+      )}
+    </>
+  );
+};
+
+export default TabPanel;

--- a/src/components/Tab/TabPanels.tsx
+++ b/src/components/Tab/TabPanels.tsx
@@ -1,0 +1,17 @@
+/** @jsxImportSource @emotion/react */
+
+import { PropsWithChildren } from 'react';
+import { createChildrenWithId } from './useTab';
+import { css } from '@emotion/react';
+
+const TabPanels = ({ children }: PropsWithChildren) => {
+  const childrenWithId = createChildrenWithId(children);
+
+  return <div css={tabPanelsStyle}>{childrenWithId}</div>;
+};
+
+export default TabPanels;
+
+const tabPanelsStyle = css({
+  padding: '1rem',
+});

--- a/src/components/Tab/TabProvider.tsx
+++ b/src/components/Tab/TabProvider.tsx
@@ -1,0 +1,38 @@
+import { PropsWithChildren, useEffect, useState } from 'react';
+import { TabContext } from './useTab';
+
+type Props = {
+  width?: string;
+  defaultIndex?: number;
+  index?: number;
+  onChange?: any;
+};
+
+const TabProvider = ({
+  width = '100%',
+  defaultIndex = 0,
+  index,
+  onChange,
+  children,
+}: PropsWithChildren<Props>) => {
+  const [tabIndex, setTabIndex] = useState(defaultIndex);
+
+  const onTabIndexChange = (index: number) => {
+    setTabIndex(index);
+    onChange?.(index);
+  };
+
+  const value = { tabIndex, onTabIndexChange };
+
+  useEffect(() => {
+    if (index) setTabIndex(index);
+  }, [index]);
+
+  return (
+    <TabContext.Provider value={value}>
+      <div style={{ width: `${width}` }}>{children}</div>
+    </TabContext.Provider>
+  );
+};
+
+export default TabProvider;

--- a/src/components/Tab/Tabs.tsx
+++ b/src/components/Tab/Tabs.tsx
@@ -1,0 +1,25 @@
+/** @jsxImportSource @emotion/react */
+
+import { PropsWithChildren } from 'react';
+import { createChildrenWithId } from './useTab';
+import { css } from '@emotion/react';
+
+const Tabs = ({ children }: PropsWithChildren) => {
+  const childrenWithId = createChildrenWithId(children);
+
+  return (
+    <div css={tabsStyle} role='tablist'>
+      {childrenWithId}
+    </div>
+  );
+};
+
+export default Tabs;
+
+const tabsStyle = css({
+  display: 'flex',
+  backgroundColor: '#d9d9d9',
+  gap: '0.4rem',
+  padding: '0.5rem',
+  borderRadius: '8px',
+});

--- a/src/components/Tab/useTab.ts
+++ b/src/components/Tab/useTab.ts
@@ -1,0 +1,29 @@
+import {
+  Children,
+  ReactElement,
+  ReactNode,
+  cloneElement,
+  createContext,
+  isValidElement,
+  useContext,
+} from 'react';
+
+export const TabContext = createContext<{
+  tabIndex: number;
+  onTabIndexChange: (index: number) => void;
+} | null>(null);
+
+export const useTabContext = () => {
+  const value = useContext(TabContext);
+
+  if (!value) throw Error('TabContext가 존재하지 않습니다.');
+
+  return value;
+};
+
+export const createChildrenWithId = (children: ReactNode) =>
+  Children.map(children, (child, index) => {
+    if (!child || !isValidElement(child)) return null;
+
+    return cloneElement(child as ReactElement, { tabId: index });
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,8 @@
 export { default as Container } from './components/Container';
 export { default as Flex } from './components/Flex';
 export { default as Grid } from './components/Grid';
+export { default as Tab } from './components/Tab/Tab';
+export { default as Tabs } from './components/Tab/Tabs';
+export { default as TabPanel } from './components/Tab/TabPanel';
+export { default as TabPanels } from './components/Tab/TabPanels';
+export { default as TabProvider } from './components/Tab/TabProvider';


### PR DESCRIPTION
안녕하세요 우코? 돌아온 2단계 미션도 잘 부탁드립니다!

# 🎯 2단계. 고급 레이아웃 컴포넌트

## 공통
- [x] 의미있는 커밋 메시지 작성
- [x] PR에 관련 없는 변경 사항이 포함 유무 확인

## 컴포넌트 요구사항
- [x] 선택한 컴포넌트의 기능 구현
- [x] npm 배포
- [x] README.md에 코드 저자로서 특히 고민한 부분과 의도 설명

## 📌 구현한 내용 설명

제가 구현한 Tab 레이아웃은 저희 동글 서비스에 현재 사용하고 있는 tab에 초점을 맞춰서 추상화를 진행해보았습니다. 따라서 css 보다 기능에 좀더 추상화를 신경썼습니다.

![0926](https://github.com/woowacourse/layout-component/assets/57815133/59d519c2-7927-45f6-8c81-b25801e48099)

라벨이 없이 아이콘으로만 이루어진 탭이 가능해야하고,
보시다시피 숨겨진 탭도 존재합니다.

### Controlled Tabs

여기서 더 신경쓴 부분은 default로는 index를 tab에서 직접 관리해서 밖에서 index를 넣어줄 필요없이 알아서 순서에 맞게 tabIndex를 관리하는데, [Controlled Tabs](https://nangkyeonglim.github.io/react-layout-component-docs/docs/navigation/tab#controlled-tabs)로도 이용이 가능하다는 점입니다. 

Controlled Tabs는 index와 onChange를 밖에서 넣어주어서 외부에서 tabIndex 관리가 가능하고 탭 인덱스가 변하면 onChange를 실행해 줄 수도 있습니다.
그러면 외부에 어떠한 버튼 등을 통해서 탭을 이동 시킬 수 있습니다.

이 기능을 넣어준 이유는 숨겨진 판넬로 가는 버튼이 있는 예시 문서를 참고하면 이해하기 더 쉬울 것 같습니다!
(이 아이디어는 chakra를 참고하였습니다!)

### Accessibility: ARIA

그리고 동글에서 현재 이 탭 레이아웃은 발행을 할 때 사용되는 가장 중요한 로직으로 접근성 처리가 되어있는데요. 
기존에 동글에서 적용하고 있던 접근성(role과 aria-labelledby)과 더불어서 aria-controls, aria-selected 등을 사용하여 더욱 사용자를 위한 접근성에 신경을 써 보았습니다.

<img width="430" alt="image" src="https://github.com/woowacourse/layout-component/assets/57815133/019d1805-4f41-4f76-bba8-e1a9ac822c74">


## 📸 스크린샷 

npm: https://www.npmjs.com/package/@fine1012/react-layout-component
문서: https://nangkyeonglim.github.io/react-layout-component-docs/docs/category/navigation


## 🔗 참고 링크 

mui와 chakra ui를 많이 참고했습니다. 특히 chakra ui repo에서 영감을 얻는 데 도움이 되었습니다..

https://mui.com/material-ui/react-tabs/
https://chakra-ui.com/docs/components/tabs
https://github.com/chakra-ui/chakra-ui/tree/main/packages/components/tabs