### PR TITLE
[고급 레이아웃 컴포넌트] 아이크(하지원) 미션 제출합니다. 

### DIFF
--- a/layout-component/README.md
+++ b/layout-component/README.md
@@ -22,7 +22,7 @@ Container **컴포넌트는 CSS의 기본적인 레이아웃 속성을 설정할
 
 # **Usage**
 
-```
+```jsx
 function App() {
   return (
     <Container
@@ -61,7 +61,7 @@ export default App;
 
 # **Usage**
 
-````
+```jsx
 function App() {
   return (
     <Flex
@@ -77,7 +77,8 @@ function App() {
     </Flex>
   );
 }
-export default App;```
+export default App;
+```
 
 ![Alt text](image-1.png)
 
@@ -98,8 +99,8 @@ export default App;```
 **그 외에도 ContainerProps에서 상속받은 모든 props를 사용할 수 있습니다.**
 
 # **Usage**
-````
 
+```jsx
 function App() {
 return (
 <Grid 
@@ -120,4 +121,32 @@ export default App;
 
 ```
 ![Alt text](image-2.png)
-```
+
+# Masonry 컴포넌트
+
+`Masonry`는 Pinterest 스타일의 레이아웃을 생성하는 데 사용되는 범용 컴포넌트입니다. 이 컴포넌트는 여러 열로 구성된 그리드를 만들며, 각 항목은 가장 짧은 열에 추가됩니다.
+
+## Props
+
+- **`columns`:** 그리드의 열 수를 설정합니다. 숫자를 입력받습니다.
+- **`gap`:** 그리드 셀 사이의 간격을 설정합니다. 숫자를 입력받습니다.
+- **`children`:** Masonry 레이아웃 내부에 배치할 요소들입니다. ReactNode 타입을 받습니다.
+
+## 사용법
+
+```jsx
+import { Masonry } from './components/Masonry';
+
+function App() {
+  return (
+    <Masonry columns={3} gap={10}>
+      <div style={{ height: '200px', background: '#8e44ad' }} />
+      <div style={{ height: '300px', background: '#3498db' }} />
+      <div style={{ height: '250px', background: '#c0392b' }} />
+      <div style={{ height: '350px', background: '#f1c40f' }} />
+      {/* 필요한 만큼 항목 추가 */}
+    </Masonry>
+  );
+}
+
+export default App;

--- a/layout-component/package.json
+++ b/layout-component/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eyk-layout-component",
   "private": false,
-  "version": "1.0.5",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/layout-component/src/lib/components/Masonry.tsx
+++ b/layout-component/src/lib/components/Masonry.tsx
@@ -1,0 +1,67 @@
+import React, {
+  useState,
+  useEffect,
+  ReactNode,
+  ReactElement,
+  Children,
+  isValidElement,
+} from "react";
+
+interface MasonryLayoutProps {
+  columns: number;
+  children: ReactNode;
+}
+
+function distributeChildrenIntoColumns(children: ReactNode, columns: number) {
+  const columnWrapper = Array.from(
+    { length: columns },
+    () => [] as (ReactElement | null)[]
+  );
+  const columnHeights = Array.from({ length: columns }, () => 0);
+  const marginBottom = 16;
+
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) return;
+
+    const elementChild = child as ReactElement;
+    const shortestColumnIndex = columnHeights.indexOf(
+      Math.min(...columnHeights)
+    );
+    const itemHeight = parseInt(
+      elementChild.props.style.height?.toString().replace("px", "") || "0",
+      10
+    );
+
+    const newChild = (
+      <elementChild.type
+        {...elementChild.props}
+        style={{ ...elementChild.props.style, marginBottom }}
+      />
+    );
+
+    columnWrapper[shortestColumnIndex].push(newChild);
+    columnHeights[shortestColumnIndex] += itemHeight + marginBottom;
+  });
+
+  return columnWrapper;
+}
+
+export const Masonry = ({ columns, children }: MasonryLayoutProps) => {
+  const [columnWrapper, setColumnWrapper] = useState<
+    Array<(React.ReactElement | null)[]>
+  >([]);
+
+  useEffect(() => {
+    setColumnWrapper(distributeChildrenIntoColumns(children, columns));
+  }, [columns, children]);
+
+  return (
+    <div style={{ display: "flex" }}>
+      {columnWrapper.map((columnItems, columnIndex) => (
+        <div key={`column${columnIndex}`} style={{ margin: "1em", flex: "1" }}>
+          {columnItems}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/layout-component/src/lib/components/Masonry.tsx
+++ b/layout-component/src/lib/components/Masonry.tsx
@@ -28,14 +28,14 @@ function distributeChildrenIntoColumns(children: ReactNode, columns: number) {
       Math.min(...columnHeights)
     );
     const itemHeight = parseInt(
-      elementChild.props.style.height?.toString().replace("px", "") || "0",
+      elementChild.props.style?.height?.toString().replace("px", "") || "0",
       10
     );
 
     const newChild = (
       <elementChild.type
         {...elementChild.props}
-        style={{ ...elementChild.props.style, marginBottom }}
+        style={{ ...elementChild.props.style, marginBottom, width: "100%" }}
       />
     );
 

--- a/layout-component/src/lib/components/Masonry.tsx
+++ b/layout-component/src/lib/components/Masonry.tsx
@@ -6,6 +6,7 @@ import React, {
   Children,
   isValidElement,
 } from "react";
+import styled from "styled-components";
 
 interface MasonryLayoutProps {
   columns: number;
@@ -55,8 +56,6 @@ function distributeChildrenIntoColumns(
 }
 
 export const Masonry = ({ columns, children, gap }: MasonryLayoutProps) => {
-  // 여기에 새로운 prop을 추가합니다.
-
   const [columnWrapper, setColumnWrapper] = useState<
     Array<(React.ReactElement | null)[]>
   >([]);
@@ -66,12 +65,21 @@ export const Masonry = ({ columns, children, gap }: MasonryLayoutProps) => {
   }, [columns, children, gap]);
 
   return (
-    <div style={{ display: "flex" }}>
+    <ColumnWrapper>
       {columnWrapper.map((columnItems, columnIndex) => (
-        <div key={`column${columnIndex}`} style={{ margin: "1em", flex: "1" }}>
+        <MasonryContainer key={`column${columnIndex}`}>
           {columnItems}
-        </div>
+        </MasonryContainer>
       ))}
-    </div>
+    </ColumnWrapper>
   );
 };
+
+const MasonryContainer = styled.div`
+  display: flex;
+`;
+
+const ColumnWrapper = styled.div`
+  margin: 1em;
+  flex: 1;
+`;

--- a/layout-component/src/lib/components/Masonry.tsx
+++ b/layout-component/src/lib/components/Masonry.tsx
@@ -9,16 +9,20 @@ import React, {
 
 interface MasonryLayoutProps {
   columns: number;
+  gap: number;
   children: ReactNode;
 }
 
-function distributeChildrenIntoColumns(children: ReactNode, columns: number) {
+function distributeChildrenIntoColumns(
+  children: ReactNode,
+  columns: number,
+  gap: number
+) {
   const columnWrapper = Array.from(
     { length: columns },
     () => [] as (ReactElement | null)[]
   );
   const columnHeights = Array.from({ length: columns }, () => 0);
-  const marginBottom = 16;
 
   Children.forEach(children, (child) => {
     if (!isValidElement(child)) return;
@@ -35,25 +39,31 @@ function distributeChildrenIntoColumns(children: ReactNode, columns: number) {
     const newChild = (
       <elementChild.type
         {...elementChild.props}
-        style={{ ...elementChild.props.style, marginBottom, width: "100%" }}
+        style={{
+          ...elementChild.props.style,
+          marginBottom: gap,
+          width: "100%",
+        }}
       />
     );
 
     columnWrapper[shortestColumnIndex].push(newChild);
-    columnHeights[shortestColumnIndex] += itemHeight + marginBottom;
+    columnHeights[shortestColumnIndex] += itemHeight + gap;
   });
 
   return columnWrapper;
 }
 
-export const Masonry = ({ columns, children }: MasonryLayoutProps) => {
+export const Masonry = ({ columns, children, gap }: MasonryLayoutProps) => {
+  // 여기에 새로운 prop을 추가합니다.
+
   const [columnWrapper, setColumnWrapper] = useState<
     Array<(React.ReactElement | null)[]>
   >([]);
 
   useEffect(() => {
-    setColumnWrapper(distributeChildrenIntoColumns(children, columns));
-  }, [columns, children]);
+    setColumnWrapper(distributeChildrenIntoColumns(children, columns, gap));
+  }, [columns, children, gap]);
 
   return (
     <div style={{ display: "flex" }}>

--- a/layout-component/src/main.tsx
+++ b/layout-component/src/main.tsx
@@ -1,21 +1,18 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { Grid } from "./lib/components/Grid";
+import { Masonry } from "./lib/components/Masonry";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <Grid
-      rows={2}
-      columns={2}
-      gap={10}
-      width="100vw"
-      height="100vh"
-      backgroundColor="blue"
-    >
-      <div>Item 1</div>
-      <div>Item 2</div>
-      <div>Item 3</div>
-      <div>Item 4</div>
-    </Grid>
+    <Masonry columns={4}>
+      <div style={{ background: "red", height: "200px" }}>1</div>
+      <div style={{ background: "yellow", height: "280px" }}>2</div>
+      <div style={{ background: "blue", height: "100px" }}>3</div>
+      <div style={{ background: "green", height: "340px" }}>4</div>
+      <div style={{ background: "red", height: "200px" }}>5</div>
+      <div style={{ background: "yellow", height: "260px" }}>6</div>
+      <div style={{ background: "blue", height: "120px" }}>7</div>
+      <div style={{ background: "green", height: "40px" }}>8</div>
+    </Masonry>
   </React.StrictMode>
 );

--- a/layout-component/src/main.tsx
+++ b/layout-component/src/main.tsx
@@ -5,14 +5,15 @@ import { Masonry } from "./lib/components/Masonry";
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <Masonry columns={4}>
-      <div style={{ background: "red", height: "200px" }}>1</div>
+      <img src="https://picsum.photos/200/300" />
       <div style={{ background: "yellow", height: "280px" }}>2</div>
-      <div style={{ background: "blue", height: "100px" }}>3</div>
-      <div style={{ background: "green", height: "340px" }}>4</div>
-      <div style={{ background: "red", height: "200px" }}>5</div>
-      <div style={{ background: "yellow", height: "260px" }}>6</div>
-      <div style={{ background: "blue", height: "120px" }}>7</div>
-      <div style={{ background: "green", height: "40px" }}>8</div>
+      <img src="https://picsum.photos/300/200" />
+      <div style={{ background: "blue", height: "100px" }}>4</div>
+      <div style={{ background: "green", height: "340px" }}>5</div>
+      <div style={{ background: "red", height: "200px" }}>6</div>
+      <div style={{ background: "yellow", height: "260px" }}>7</div>
+      <div style={{ background: "blue", height: "120px" }}>8</div>
+      <div style={{ background: "green", height: "40px" }}>9</div>
     </Masonry>
   </React.StrictMode>
 );


### PR DESCRIPTION
# 🎯 2단계. 고급 레이아웃 컴포넌트

## 공통
- [x] 의미있는 커밋 메시지 작성
- [x] PR에 관련 없는 변경 사항이 포함 유무 확인

## 컴포넌트 요구사항
- [ ] 선택한 컴포넌트의 기능 구현
- [x] npm 배포
- [x] README.md에 코드 저자로서 특히 고민한 부분과 의도 설명
- [ ] 테스트 코드를 작성하였나요? (선택 사항)

## 📌 구현한 내용 설명
Masonry를 선택해서 구현해봤습니다
처음엔 단순하게 Masonry의 자식 컴포넌트들 각각의 높이값을 가져와서 균등하게 배분해주면 되겠지라고 생각하고 시작했습니다
어떻게 균등하게 배분할 것인가를 생각했을 때 처음 사용했던 방식은 열의 갯수만큼 순서대로 첫번째부터 마지막 열까지 채우고 다시 첫번째 열에 넣는 방식으로 했습니다.
이후에는 현재까지의 열의 높이 중 최소 높이의 열에 넣는 방식으로 구현했습니다
문제는 요구사항에 나와있는 것처럼 자식요소가 모두 div로 감싸져 있는 경우는 쉽게 해결되었지만  이미지 같은 경우는 렌더링이 되기 전에는 높이값을 알 수 없는 문제가 생겨서 제 masonry 컴포넌트는 div로 감싼 것만 사용해야됩니다 도리^^
(여기에 구현한 내용에 대한 설명과 고민한 부분, 어려웠던 점 등을 자세히 작성)


