### PR TITLE
[고급 레이아웃 컴포넌트] 황펭(양이진) 미션 제출합니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,20 @@ import { Drawer } from 'layout-component-hp';
 - Drawer.Content: Drawer 내부 컨텐트
 - Drawer.CloseButton: Drawer를 닫을 수 있는 버튼
 
+### useDisclosure
+
+```tsx
+import { useDisclosure } from 'layout-component-hp';
+
+const { isOpen, onOpen, onClose } = useDisclosure();
+```
+
+Drawer를 동작할 수 있는 useDisclosure 훅을 제공
+
+- isOpen: Drawer가 열려있는지에 대한 상태
+- onOpen: Drawer를 여는 함수
+- onClose: Drawer를 닫는 함수
+
 ### Drawer Props
 
 | props         | value                               | description                                    |

--- a/README.md
+++ b/README.md
@@ -148,3 +148,65 @@ import { Flex } from 'layout-component-hp';
   <Flex.Item>Item2</Flex.Item>
 </Flex>
 ```
+
+<br>
+
+## Drawer
+
+화면의 한쪽에서 슬라이드 형태로 나타나는 메뉴나 사이드바를 제공하는 컴포넌트
+
+### Import
+
+```tsx
+import { Drawer } from 'layout-component-hp';
+```
+
+### Anatomy
+
+- Drawer: 화면의 한쪽에서 슬라이드 형태로 나타나는 메뉴나 사이드바
+- Drawer.Backdrop: Drawer 외부 백그라운드. 클릭으로 Drawer를 닫을 수 있습니다
+- Drawer.Content: Drawer 내부 컨텐트
+- Drawer.CloseButton: Drawer를 닫을 수 있는 버튼
+
+### Drawer Props
+
+| props         | value                               | description                                    |
+| ------------- | ----------------------------------- | ---------------------------------------------- |
+| isOpen        | boolean                             | Drawer가 열려있는지 여부입니다.                |
+| onClose       | () => void                          | Drawer를 닫는 함수입니다.                      |
+| animation?    | boolean (default: true)             | Drawer의 열고 닫는 애니메이션 지정 여부입니다. |
+| placement?    | 'top' / 'right' / 'bottom' / 'left' | Drawer의 위치입니다.                           |
+| portalElement | Element (default: document.body)    | Drawer가 렌더링될 위치입니다.                  |
+| children      | ReactElement                        | Drawer의 자식 컴포넌트입니다.                  |
+
+### Drawer.Content Props
+
+| props    | value                       | description                                |
+| -------- | --------------------------- | ------------------------------------------ |
+| css?     | CSSProperties (default: {}) | Drawer.Content의 커스텀 스타일 속성입니다. |
+| children | ReactNode                   | Drawer.Content의 자식 컴포넌트입니다.      |
+
+### Usage
+
+```tsx
+import { Drawer, useDisclosure } from 'layout-component-hp';
+
+function DrawerWithButton() {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  return (
+    <>
+      <button type='button' onClick={onOpen}>
+        Open Drawer
+      </button>
+      <Drawer isOpen={isOpen} onClose={onClose} placement='right'>
+        <Drawer.Backdrop />
+        <Drawer.Content>
+          <Drawer.CloseButton />
+          <p>This is Drawer</p>
+        </Drawer.Content>
+      </Drawer>;
+    </>
+  );
+}
+```

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ import { Drawer } from 'layout-component-hp';
 ```tsx
 import { Drawer, useDisclosure } from 'layout-component-hp';
 
-function DrawerWithButton() {
+function DrawerExample() {
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   return (
@@ -205,7 +205,7 @@ function DrawerWithButton() {
           <Drawer.CloseButton />
           <p>This is Drawer</p>
         </Drawer.Content>
-      </Drawer>;
+      </Drawer>
     </>
   );
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "layout-component-hp",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/cjs/types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "layout-component-hp",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/cjs/types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "layout-component-hp",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/cjs/types/index.d.ts",

--- a/src/drawer/drawer-backdrop.module.css
+++ b/src/drawer/drawer-backdrop.module.css
@@ -1,0 +1,9 @@
+.backdrop {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background: rgba(0, 0, 0, 0.35);
+  z-index: 1000;
+}

--- a/src/drawer/drawer-backdrop.tsx
+++ b/src/drawer/drawer-backdrop.tsx
@@ -5,14 +5,7 @@ import styles from './drawer-backdrop.module.css';
 const DrawerBackdrop = () => {
   const { onClose } = useDrawerContext();
 
-  return (
-    <button
-      type='button'
-      className={styles.backdrop}
-      onClick={onClose}
-      aria-hidden
-    />
-  );
+  return <div className={styles.backdrop} onClick={onClose} aria-hidden />;
 };
 
 export default DrawerBackdrop;

--- a/src/drawer/drawer-backdrop.tsx
+++ b/src/drawer/drawer-backdrop.tsx
@@ -1,0 +1,18 @@
+import { useDrawerContext } from './drawer-context';
+
+import styles from './drawer-backdrop.module.css';
+
+const DrawerBackdrop = () => {
+  const { onClose } = useDrawerContext();
+
+  return (
+    <button
+      type='button'
+      className={styles.backdrop}
+      onClick={onClose}
+      aria-hidden
+    />
+  );
+};
+
+export default DrawerBackdrop;

--- a/src/drawer/drawer-close-button.module.css
+++ b/src/drawer/drawer-close-button.module.css
@@ -1,0 +1,14 @@
+.close-button {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  font-size: 18px;
+  line-height: 20px;
+  text-align: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+}

--- a/src/drawer/drawer-close-button.tsx
+++ b/src/drawer/drawer-close-button.tsx
@@ -1,0 +1,20 @@
+import { useDrawerContext } from './drawer-context';
+
+import styles from './drawer-close-button.module.css';
+
+const DrawerCloseButton = () => {
+  const { onClose } = useDrawerContext();
+
+  return (
+    <button
+      type='button'
+      className={styles['close-button']}
+      onClick={onClose}
+      aria-label='close drawer'
+    >
+      X
+    </button>
+  );
+};
+
+export default DrawerCloseButton;

--- a/src/drawer/drawer-content.module.css
+++ b/src/drawer/drawer-content.module.css
@@ -18,10 +18,12 @@
 
 .left {
   left: 0;
+  border-right: 1px solid #e0e0e0;
 }
 
 .right {
   right: 0;
+  border-left: 1px solid #e0e0e0;
 }
 
 .top,
@@ -33,10 +35,12 @@
 
 .top {
   top: 0;
+  border-bottom: 1px solid #e0e0e0;
 }
 
 .bottom {
   bottom: 0;
+  border-top: 1px solid #e0e0e0;
 }
 
 .animation-left {

--- a/src/drawer/drawer-content.module.css
+++ b/src/drawer/drawer-content.module.css
@@ -1,0 +1,152 @@
+.content {
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 300px;
+  max-height: 100vh;
+  z-index: 1001;
+  background: #ffffff;
+  transform: translateX(0%) translateY(0px) translateZ(0px);
+}
+
+.left,
+.right {
+  top: 0;
+  bottom: 0;
+}
+
+.left {
+  left: 0;
+}
+
+.right {
+  right: 0;
+}
+
+.top,
+.bottom {
+  left: 0;
+  right: 0;
+  max-width: 100vw;
+}
+
+.top {
+  top: 0;
+}
+
+.bottom {
+  bottom: 0;
+}
+
+.animation-left {
+  animation: 0.3s showFromLeft ease-out;
+}
+
+.animation-left.close-left {
+  animation: 0.3s hideToLeft;
+}
+
+.animation-right {
+  animation: 0.3s showFromRight ease-out;
+}
+
+.animation-right.close-right {
+  animation: 0.3s hideToRight;
+}
+
+.animation-top {
+  animation: 0.3s showFromTop ease-out;
+}
+
+.animation-top.close-top {
+  animation: 1s hideToTop;
+}
+
+.animation-bottom {
+  animation: 0.3s showFromBottom ease-out;
+}
+
+.animation-bottom.close-bottom {
+  animation: 1s hideToBottom;
+}
+
+@keyframes showFromLeft {
+  from {
+    transform: translateX(-300px);
+  }
+
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes hideToLeft {
+  from {
+    transform: translateY(0);
+  }
+
+  to {
+    transform: translateX(-300px);
+  }
+}
+
+@keyframes showFromRight {
+  from {
+    transform: translateX(300px);
+  }
+
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes hideToRight {
+  from {
+    transform: translateY(0);
+  }
+
+  to {
+    transform: translateX(300px);
+  }
+}
+
+@keyframes showFromBottom {
+  from {
+    transform: translateY(300px);
+  }
+
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes hideToBottom {
+  from {
+    transform: translateY(0);
+  }
+
+  to {
+    transform: translateY(300px);
+  }
+}
+
+@keyframes showFromTop {
+  from {
+    transform: translateY(-300px);
+  }
+
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes hideToTop {
+  from {
+    transform: translateY(0);
+  }
+
+  to {
+    transform: translateY(-300px);
+  }
+}

--- a/src/drawer/drawer-content.module.css
+++ b/src/drawer/drawer-content.module.css
@@ -7,7 +7,7 @@
   max-height: 100vh;
   z-index: 1001;
   background: #ffffff;
-  transform: translateX(0%) translateY(0px) translateZ(0px);
+  transform: translateX(0) translateY(0) translateZ(0);
 }
 
 .left,

--- a/src/drawer/drawer-content.tsx
+++ b/src/drawer/drawer-content.tsx
@@ -7,7 +7,7 @@ import styles from './drawer-content.module.css';
 
 type DrawerContentProps = {
   css?: CSSProperties;
-  children: ReactElement;
+  children: ReactElement | ReactElement[];
 };
 
 const DrawerContent = ({ css = {}, children }: DrawerContentProps) => {

--- a/src/drawer/drawer-content.tsx
+++ b/src/drawer/drawer-content.tsx
@@ -1,0 +1,31 @@
+import type { CSSProperties, ReactElement } from 'react';
+import cx from 'classnames';
+
+import { useDrawerContext } from './drawer-context';
+
+import styles from './drawer-content.module.css';
+
+type DrawerContentProps = {
+  css?: CSSProperties;
+  children: ReactElement;
+};
+
+const DrawerContent = ({ css = {}, children }: DrawerContentProps) => {
+  const { animation, isCloseReady, placement } = useDrawerContext();
+
+  return (
+    <section
+      className={cx(styles.content, styles[placement], {
+        [styles[`animation-${placement}`]]: animation,
+        [styles[`close-${placement}`]]: isCloseReady,
+      })}
+      role='dialog'
+      style={css}
+      tabIndex={-1}
+    >
+      {children}
+    </section>
+  );
+};
+
+export default DrawerContent;

--- a/src/drawer/drawer-context.ts
+++ b/src/drawer/drawer-context.ts
@@ -1,0 +1,23 @@
+import { createContext, useContext } from 'react';
+import type { Placement } from './drawer.type';
+
+type DrawerConfig = {
+  animation: boolean;
+  isCloseReady: boolean;
+  onClose: () => void;
+  placement: Placement;
+};
+
+export const DrawerContext = createContext<DrawerConfig | null>(null);
+
+export const useDrawerContext = () => {
+  const context = useContext(DrawerContext);
+
+  if (!context) {
+    throw new Error(
+      'useDrawerContext: "context" is undefined. Did you forget to wrap your component in <Drawer />?'
+    );
+  }
+
+  return context;
+};

--- a/src/drawer/drawer.tsx
+++ b/src/drawer/drawer.tsx
@@ -14,7 +14,7 @@ type DrawerProps = {
   animation?: boolean;
   placement?: Placement;
   portalElement?: Element;
-  children: ReactElement;
+  children: ReactElement | ReactElement[];
 };
 
 const Drawer = ({

--- a/src/drawer/drawer.tsx
+++ b/src/drawer/drawer.tsx
@@ -1,0 +1,47 @@
+import type { ReactElement } from 'react';
+import { createPortal } from 'react-dom';
+
+import DrawerContent from './drawer-content';
+import DrawerBackdrop from './drawer-backdrop';
+import { DrawerContext } from './drawer-context';
+import { useDrawer } from './hooks';
+import { Placement } from './drawer.type';
+
+type DrawerProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  animation?: boolean;
+  placement?: Placement;
+  portalElement?: Element;
+  children: ReactElement;
+};
+
+const Drawer = ({
+  isOpen,
+  onClose,
+  animation = true,
+  placement = 'left',
+  portalElement = document.body,
+  children,
+}: DrawerProps) => {
+  const { isCloseReady, closeDrawer } = useDrawer({ animation, onClose });
+
+  const drawerConfig = {
+    animation,
+    isCloseReady,
+    placement,
+    onClose: closeDrawer,
+  };
+
+  return createPortal(
+    <DrawerContext.Provider value={drawerConfig}>
+      {isOpen ? children : null}
+    </DrawerContext.Provider>,
+    portalElement
+  );
+};
+
+Drawer.Backdrop = DrawerBackdrop;
+Drawer.Content = DrawerContent;
+
+export default Drawer;

--- a/src/drawer/drawer.tsx
+++ b/src/drawer/drawer.tsx
@@ -6,6 +6,7 @@ import DrawerBackdrop from './drawer-backdrop';
 import { DrawerContext } from './drawer-context';
 import { useDrawer } from './hooks';
 import { Placement } from './drawer.type';
+import DrawerCloseButton from './drawer-close-button';
 
 type DrawerProps = {
   isOpen: boolean;
@@ -43,5 +44,6 @@ const Drawer = ({
 
 Drawer.Backdrop = DrawerBackdrop;
 Drawer.Content = DrawerContent;
+Drawer.CloseButton = DrawerCloseButton;
 
 export default Drawer;

--- a/src/drawer/drawer.type.ts
+++ b/src/drawer/drawer.type.ts
@@ -1,0 +1,1 @@
+export type Placement = 'top' | 'right' | 'bottom' | 'left';

--- a/src/drawer/hooks/index.ts
+++ b/src/drawer/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './use-drawer';
+export * from './use-disclosure';

--- a/src/drawer/hooks/use-disclosure.ts
+++ b/src/drawer/hooks/use-disclosure.ts
@@ -1,0 +1,15 @@
+import { useCallback, useState } from 'react';
+
+export const useDisclosure = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const onOpen = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+
+  const onClose = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  return { isOpen, onOpen, onClose };
+};

--- a/src/drawer/hooks/use-drawer.ts
+++ b/src/drawer/hooks/use-drawer.ts
@@ -1,0 +1,24 @@
+import { useCallback, useState } from 'react';
+
+type UseDrawerProps = {
+  animation: boolean;
+  onClose: () => void;
+};
+
+export const useDrawer = ({ animation, onClose }: UseDrawerProps) => {
+  const [isCloseReady, setIsCloseReady] = useState(false);
+
+  const closeAnimated = useCallback(() => {
+    setIsCloseReady(true);
+
+    const timer = setTimeout(() => {
+      setIsCloseReady(false);
+      onClose();
+      clearTimeout(timer);
+    }, 200);
+  }, []);
+
+  const closeDrawer = animation ? closeAnimated : onClose;
+
+  return { isCloseReady, closeDrawer };
+};

--- a/src/drawer/index.ts
+++ b/src/drawer/index.ts
@@ -1,0 +1,6 @@
+import Drawer from './drawer';
+
+export * from './hooks';
+export * from './drawer-context';
+
+export default Drawer;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
 export { default as Container } from './container';
 export { default as Flex } from './flex';
 export { default as Grid } from './grid';
+
+export { default as Drawer } from './drawer';
+export * from './drawer';


### PR DESCRIPTION
# 🎯 2단계. 고급 레이아웃 컴포넌트

코난 안녕하세요! 이번엔 Drawer 컴포넌트를 가져왔습니다.
리뷰 부탁드려요~!

## 공통
- [x] 의미있는 커밋 메시지 작성
- [x] PR에 관련 없는 변경 사항이 포함 유무 확인

## 컴포넌트 요구사항
- [x] 선택한 컴포넌트의 기능 구현
- [x] npm 배포
- [x] README.md에 코드 저자로서 특히 고민한 부분과 의도 설명

## 📌 구현한 내용 설명

- Drawer 컴포넌트를 구현했습니다.
- 사용자가 open 상태와 핸들링할 수 있는 함수를 쉽게 사용하기 위해 useDisclosure 훅을 작성했습니다.
- placement 속성으로 Drawer의 위치를 설정할 수 있습니다.
- Drawer.Backdrop 컴포넌트를 사용해 바깥 클릭으로 Drawer를 닫을 수 있고, Drawer.CloseButton 컴포넌트로 내부 닫기 버튼을 추가할 수 있습니다.
- 내부 내용은 Drawer.Content에 담아서 사용하면 됩니다.

## 📸 스크린샷 (선택 사항)

### [컴포넌트 문서](https://leejin-yang.github.io/component-docs/docs/layout/drawer)에서 확인해주세요~
### [NPM 주소](https://www.npmjs.com/package/layout-component-hp)
